### PR TITLE
Update google.maps.d.ts

### DIFF
--- a/google.maps.d.ts
+++ b/google.maps.d.ts
@@ -32,8 +32,7 @@ declare module google.maps {
         get(key: string): any;
         notify(key: string): void;
         set(key: string, value: any): void;
-        setValues(values: any): void;
-        setValues(values: undefined);
+        setValues(values?: any): void;
         unbind(key: string): void;
         unbindAll(): void;
     }


### PR DESCRIPTION
setValues(values: undefined): void; does not compile after TypeScript upgrades to v0.9

To fix the problem, just need to make values as nullable type.
