### PR TITLE
fixed: Polyline getPath

### DIFF
--- a/google.maps.d.ts
+++ b/google.maps.d.ts
@@ -307,13 +307,13 @@ declare module google.maps {
         constructor (opts?: PolylineOptions);
         getEditable(): boolean;
         getMap(): Map;
-        getPath(): MVCArray[];
+        getPath(): MVCArray<LatLng>;
         getVisible(): boolean;
         setEditable(editable: boolean): void;
         setMap(map: Map): void;
         setOptions(options: PolylineOptions): void;
-        setPath(path: MVCArray[]): void;
-        setPath(path: LatLng[]): void;
+        setPath(path: MVCArray<LatLng>): void;
+        setPath(path: LatLng[] | MVCArray<LatLng>): void;
         setVisible(visible: boolean): void;
     }
 


### PR DESCRIPTION
method 'getPath()' should return MVCArray<LatLng>;
reference: https://developers.google.com/maps/documentation/javascript/3.exp/reference#Polyline